### PR TITLE
Fix missing ifdef __VXWORKS__ in socket_select_interrupter definition

### DIFF
--- a/asio/include/asio/detail/impl/socket_select_interrupter.ipp
+++ b/asio/include/asio/detail/impl/socket_select_interrupter.ipp
@@ -21,7 +21,8 @@
 
 #if defined(ASIO_WINDOWS) \
   || defined(__CYGWIN__) \
-  || defined(__SYMBIAN32__)
+  || defined(__SYMBIAN32__) \
+  || defined(__VXWORKS__)
 
 #include <cstdlib>
 #include "asio/detail/socket_holder.hpp"
@@ -170,6 +171,7 @@ bool socket_select_interrupter::reset()
 #endif // defined(ASIO_WINDOWS)
        // || defined(__CYGWIN__)
        // || defined(__SYMBIAN32__)
+       // || defined(__VXWORKS__)
 
 #endif // !defined(ASIO_WINDOWS_RUNTIME)
 

--- a/asio/include/asio/detail/socket_select_interrupter.hpp
+++ b/asio/include/asio/detail/socket_select_interrupter.hpp
@@ -86,6 +86,7 @@ private:
 #endif // defined(ASIO_WINDOWS)
        // || defined(__CYGWIN__)
        // || defined(__SYMBIAN32__)
+       // || defined(__VXWORKS__)
 
 #endif // !defined(ASIO_WINDOWS_RUNTIME)
 


### PR DESCRIPTION
This aims at fixing this issue https://github.com/iit-danieli-joint-lab/idjl-software/issues/1040